### PR TITLE
Add flexible input for createApiMessages

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ This documentation has been reorganized for better navigation:
 - [Système de génération Markdown](./docs/architecture/markdown-generation.md) - Architecture du générateur markdown
 - [Format du backlog](./docs/architecture/backlog-format.md) - Spécification du format JSON de backlog
 
+### Helper Functions
+- **createApiMessages(project)** - Génère la paire de messages système/utilisateur pour l'IA. Le paramètre `project` peut être une chaîne de type `"Nom: description"` ou un objet `{ name, description }`.
+
 > **Note TDD** : Les assertions sur les erreurs doivent vérifier le format unifié `{ success: false, error: { message: ... } }`.
 > Toute modification du format d’erreur nécessite la mise à jour des tests d’intégration.
 

--- a/server/lib/backlog-generator.js
+++ b/server/lib/backlog-generator.js
@@ -215,13 +215,21 @@ Tout le contenu doit être pertinent pour ${projectName} et basé sur la descrip
 
 /**
  * Crée les messages pour l'API
- * @param {string} project - Description complète du projet
+ * @param {string|Object} project - Description complète du projet sous forme de chaîne "nom: description" ou objet {name, description}
  * @returns {Array} Messages formatés pour l'API
  */
 function createApiMessages(project) {
-  const splitProject = project.split(': ');
-  const projectName = splitProject[0] || 'Projet sans nom';
-  const projectDescription = splitProject[1] || 'Pas de description';
+  let projectName = 'Projet sans nom';
+  let projectDescription = 'Pas de description';
+
+  if (project && typeof project === 'object') {
+    projectName = project.name || projectName;
+    projectDescription = project.description || projectDescription;
+  } else if (typeof project === 'string') {
+    const splitProject = project.split(': ');
+    projectName = splitProject[0] || projectName;
+    projectDescription = splitProject[1] || projectDescription;
+  }
   
   return [
     _createSystemPrompt(projectName, projectDescription),

--- a/server/lib/backlog-generator.unit.test.js
+++ b/server/lib/backlog-generator.unit.test.js
@@ -22,9 +22,15 @@ describe('generateBacklog - Refactor TDD', () => {
   });
 
   describe('createApiMessages', () => {
-    it('génère un tableau de messages API cohérent', () => {
+    it('génère un tableau de messages API avec un objet', () => {
       const project = { name: 'Test', description: 'desc' };
       const messages = createApiMessages(project);
+      expect(Array.isArray(messages)).toBe(true);
+      expect(messages[0]).toHaveProperty('role');
+    });
+
+    it('génère un tableau de messages API avec une chaîne', () => {
+      const messages = createApiMessages('Test: desc');
       expect(Array.isArray(messages)).toBe(true);
       expect(messages[0]).toHaveProperty('role');
     });

--- a/tests/backlog-generator.test.js
+++ b/tests/backlog-generator.test.js
@@ -63,9 +63,15 @@ describe('backlog-generator', () => {
   });
 
   describe('createApiMessages', () => {
-    it('génère un tableau de messages API cohérent', () => {
+    it('génère un tableau de messages API avec un objet', () => {
       const project = { name: 'Test', description: 'desc' };
       const messages = createApiMessages(project);
+      expect(Array.isArray(messages)).toBe(true);
+      expect(messages[0]).toHaveProperty('role');
+    });
+
+    it('génère un tableau de messages API avec une chaîne', () => {
+      const messages = createApiMessages('Test: desc');
       expect(Array.isArray(messages)).toBe(true);
       expect(messages[0]).toHaveProperty('role');
     });


### PR DESCRIPTION
## Summary
- allow `createApiMessages` to accept a `{name, description}` object or a raw string
- update unit tests for new API
- document `createApiMessages` usage in README

## Testing
- `npm test` *(fails: jest not found / requires API keys)*

------
https://chatgpt.com/codex/tasks/task_e_68503f962e4c832a82098140c4bbfb6d