### PR TITLE
Add ToolExecutionError for failed tool calls

### DIFF
--- a/server/lib/errors.js
+++ b/server/lib/errors.js
@@ -76,6 +76,15 @@ class FileSystemError extends AgilePlannerError {
 }
 
 /**
+ * Erreur d'exécution lors de l'appel d'un outil MCP
+ */
+class ToolExecutionError extends AgilePlannerError {
+  constructor(message, details) {
+    super(message, 'TOOL_EXECUTION_ERROR', details);
+  }
+}
+
+/**
  * Erreur liée au protocole MCP
  * Compatible avec Windsurf, Claude.ai et Cursor
  */
@@ -172,5 +181,6 @@ module.exports = {
   ValidationError,
   ApiError,
   FileSystemError,
+  ToolExecutionError,
   McpError
 };

--- a/server/lib/mcp-router.js
+++ b/server/lib/mcp-router.js
@@ -1078,7 +1078,10 @@ async function handleGenerateFeature(args) {
 
     // Vérifier si le résultat est valide
     if (!result?.success) {
-      throw new Error(result?.error?.message || "Génération de la feature échouée");
+      throw new ToolExecutionError(
+        result?.error?.message || 'Génération de la feature échouée',
+        { tool: 'generateFeature' }
+      );
     }
     
     // Sauvegarde et génération des fichiers markdown


### PR DESCRIPTION
## Summary
- define `ToolExecutionError` as a subclass of `AgilePlannerError`
- export the class from the error module
- raise `ToolExecutionError` when generateFeature fails

## Testing
- `npm test` *(fails: missing API keys)*

------
https://chatgpt.com/codex/tasks/task_e_68503f976718832a9df1d082a73740d1