### PR TITLE
Use execFile in tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agile-planner-mcp-server",
-  "version": "1.6.1",
+  "version": "1.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agile-planner-mcp-server",
-      "version": "1.6.1",
+      "version": "1.7.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -2907,9 +2907,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3362,9 +3362,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/tests/integration/cli.e2e.test.js
+++ b/tests/integration/cli.e2e.test.js
@@ -1,5 +1,5 @@
 // Test d'intégration end-to-end CLI Agile Planner
-const { exec } = require('child_process');
+const { execFile } = require('child_process');
 const fs = require('fs');
 const path = require('path');
 
@@ -51,13 +51,21 @@ describe('CLI End-to-End', () => {
     
     // Exécuter la commande CLI - utiliser un chemin de sortie spécifique pour ce test
     const testOutputDir = path.join(process.cwd(), '.agile-planner-backlog-test-cli');
-    const testCmd = `node server/index.js generateBacklog "E2E Test Project" "E2E Test Description" --output ${testOutputDir}`;
-    
-    console.log('Executing CLI test command:', testCmd);
-    
-    exec(
-      testCmd, 
-      { cwd: process.cwd(), env: {...process.env} }, 
+    const testArgs = [
+      'server/index.js',
+      'generateBacklog',
+      'E2E Test Project',
+      'E2E Test Description',
+      '--output',
+      testOutputDir
+    ];
+
+    console.log('Executing CLI test command:', `node ${testArgs.join(' ')}`);
+
+    execFile(
+      'node',
+      testArgs,
+      { cwd: process.cwd(), env: {...process.env} },
       (error, stdout, stderr) => {
         // Forcer le nettoyage des ressources
         Promise.resolve()

--- a/tests/integration/isolated/generateBacklog-cli.test.js
+++ b/tests/integration/isolated/generateBacklog-cli.test.js
@@ -4,7 +4,7 @@
  * - Validation des structures conformes à RULE 3
  * - Compatible avec le mode MCP parallèle
  */
-const { exec } = require('child_process');
+const { execFile } = require('child_process');
 const fs = require('fs');
 const path = require('path');
 const TEST_TIMEOUT = 30000;
@@ -38,20 +38,25 @@ describe('GenerateBacklog CLI Mode', () => {
     // Variables pour le test
     const projectName = 'Test CLI Backlog';
     const projectDesc = 'Test description for CLI backlog generation';
-    
-    // Construire la commande CLI
-    const cliCommand = `node server/index.js generateBacklog "${projectName}" "${projectDesc}" --output "${TEST_OUTPUT_DIR}"`;
-    
-    console.log(`Executing CLI command: ${cliCommand}`);
-    
-    // Exécuter la commande CLI
-    exec(cliCommand, { 
+
+    const cliArgs = [
+      'server/index.js',
+      'generateBacklog',
+      projectName,
+      projectDesc,
+      '--output',
+      TEST_OUTPUT_DIR
+    ];
+
+    console.log(`Executing CLI command: node ${cliArgs.join(' ')}`);
+
+    execFile('node', cliArgs, {
       env: {
         ...process.env,
         NODE_ENV: 'test',
         FORCE_COLOR: '0',
         AGILE_PLANNER_TEST_MODE: 'true'
-      } 
+      }
     }, (error, stdout, stderr) => {
       // Logs pour débug
       console.log(`STDOUT: ${stdout.substring(0, 500)}...`);

--- a/tests/integration/isolated/generateFeature-cli.test.js
+++ b/tests/integration/isolated/generateFeature-cli.test.js
@@ -4,7 +4,7 @@
  * - Validation des structures conformes à RULE 3
  * - Compatible avec le mode MCP parallèle
  */
-const { exec } = require('child_process');
+const { execFile } = require('child_process');
 const fs = require('fs');
 const path = require('path');
 const TEST_TIMEOUT = 30000;
@@ -75,19 +75,25 @@ describe('GenerateFeature CLI Mode', () => {
     const featureName = 'Test Feature';
     const featureDesc = 'Test description for feature generation';
     
-    // Construire la commande CLI
-    const cliCommand = `node server/index.js generateFeature "${epicId}" "${featureName}" "${featureDesc}" --backlog-path "${TEST_OUTPUT_DIR}"`;
-    
-    console.log(`Executing CLI command: ${cliCommand}`);
-    
-    // Exécuter la commande CLI
-    exec(cliCommand, { 
+    const cliArgs = [
+      'server/index.js',
+      'generateFeature',
+      epicId,
+      featureName,
+      featureDesc,
+      '--backlog-path',
+      TEST_OUTPUT_DIR
+    ];
+
+    console.log(`Executing CLI command: node ${cliArgs.join(' ')}`);
+
+    execFile('node', cliArgs, {
       env: {
         ...process.env,
         NODE_ENV: 'test',
         FORCE_COLOR: '0',
         AGILE_PLANNER_TEST_MODE: 'true'
-      } 
+      }
     }, (error, stdout, stderr) => {
       // Logs pour débug
       console.log(`STDOUT: ${stdout.substring(0, 500)}...`);

--- a/tests/integration/isolated/ultra-minimal.test.js
+++ b/tests/integration/isolated/ultra-minimal.test.js
@@ -2,15 +2,15 @@
  * Test ultra-minimal pour valider les principes fondamentaux d'invocation du serveur MCP
  * Conformément à la RULE 1, ce test applique les principes TDD pour isoler le problème
  */
-const { spawn, exec } = require('child_process');
+const { spawn, execFile } = require('child_process');
 const TEST_TIMEOUT = 5000; // Timeout court car test minimal
 
 describe('Ultra Minimal Server Test', () => {
   it('should execute a basic command and exit cleanly - CLI mode', (done) => {
     jest.setTimeout(TEST_TIMEOUT);
     
-    // Exécuter une commande simple qui devrait réussir rapidement
-    exec('node server/index.js --version', { env: { ...process.env, FORCE_COLOR: '0' } }, (error, stdout, stderr) => {
+    const versionArgs = ['server/index.js', '--version'];
+    execFile('node', versionArgs, { env: { ...process.env, FORCE_COLOR: '0' } }, (error, stdout, stderr) => {
       expect(error).toBeNull();
       expect(stdout).toBeTruthy(); // Devrait contenir la version
       done();


### PR DESCRIPTION
## Summary
- replace `exec` with `execFile` in integration tests
- update dependencies via `npm audit fix`

## Testing
- `npm test` *(fails: A worker process has failed to exit gracefully and has been force exited)*

------
https://chatgpt.com/codex/tasks/task_e_68512fdbd0f8832ab059ea91522b1be9